### PR TITLE
Reverse git log records to order history commits chronologically

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function(command, source, _options) {
 
       const spinner = ora(`Writing history`).start();
 
-      await lines.reduce(async (lastPromise, line) => {
+      await lines.reverse().reduce(async (lastPromise, line) => {
         await lastPromise;
 
         const [hash, date] = line.split("|");


### PR DESCRIPTION
Fix history commits order: an older commit should be a parent of a younger one.